### PR TITLE
Add Alerts for adding portfolios and fix missing aria-label prop

### DIFF
--- a/src/SmartComponents/Common/AddPortfolioModal.js
+++ b/src/SmartComponents/Common/AddPortfolioModal.js
@@ -10,6 +10,8 @@ import { addPortfolioWithItem } from '../../Store/Actions/PortfolioActions';
 import { PortfolioStore } from "../../Store/Reducers/PortfolioStore";
 import { bindMethods } from "../../Helpers/Shared/Helper";
 import { FormRenderer } from '@red-hat-insights/insights-frontend-components/components/Forms'
+import { addAlert, removeAlert } from '../../Store/Actions/AlertActions';
+import Alerts from '../Common/Alerts';
 
 const schema = {
   type: 'object',
@@ -25,13 +27,26 @@ class AddPortfolioModal extends Component {
   };
 
   onSubmit = data => {
-    this.props.addPortfolioWithItem(data, this.props.itemdata);
-    console.log('Data submitted: ', data, this.props.itemdata);
+    this.props.addPortfolioWithItem(data, this.props.itemdata)
+      .then(() => this.props.addAlert({
+          variant: 'success',
+          title: 'Success adding portfolio',
+          description: 'The portfolio was added successfully.'
+      }))
+      .catch(() => this.props.addAlert({
+          variant: 'danger',
+          title: 'Failed adding portfolio',
+          description: 'The portfolio was not added successfuly.'
+      }));
     this.props.closeModal();
   }
 
   onCancel = () => {
-    console.log('Cancel Add Portfolio');
+    this.props.addAlert({
+      variant: 'warning',
+      title: 'Adding portfolio',
+      description: 'Adding portfolio was cancelled by the user.'
+    })
     this.props.closeModal();
   }
 
@@ -58,7 +73,11 @@ class AddPortfolioModal extends Component {
 
 const mapStateToProps = state => ({ isLoading: state.PortfolioStore.isLoading });
 
-const mapDispatchToProps = dispatch => bindActionCreators({ addPortfolioWithItem }, bindActionCreators)
+const mapDispatchToProps = dispatch => bindActionCreators({
+  addAlert,
+  removeAlert,
+  addPortfolioWithItem,
+}, dispatch);
 
 AddPortfolioModal.propTypes = {
   isLoading: propTypes.bool,

--- a/src/SmartComponents/Common/Alerts.js
+++ b/src/SmartComponents/Common/Alerts.js
@@ -7,7 +7,7 @@ import { TimesIcon } from '@patternfly/react-icons';
 const Alerts = ({ alerts, removeAlert }) => (
 	<div>
 		{alerts.map(({ variant, title, description }, index) => (
-			<Alert style={{marginBottom: 10}}key={index} variant={variant} title={title} action={<Button variant="plain" onClick={() => removeAlert(index)}><TimesIcon /></Button>}>
+			<Alert style={{marginBottom: 10}}key={index} variant={variant} title={title} action={<Button aria-label="Close alert" variant="plain" onClick={() => removeAlert(index)}><TimesIcon /></Button>}>
 				{description}
 			</Alert>
 		))}

--- a/src/Store/Actions/PortfolioActions.js
+++ b/src/Store/Actions/PortfolioActions.js
@@ -41,10 +41,6 @@ export const searchPortfolioItems = value => ({
 });
 
 export const addPortfolioWithItem = (portfolioData, itemData) => ({
-  type: ActionTypes.ADD_PORTFOLIO,
-  payload: new Promise(resolve => {
-    resolve(PortfolioHelper.addPortfolioWithItem(portfolioData, itemData));
+    type: ActionTypes.ADD_PORTFOLIO,
+    payload: PortfolioHelper.addPortfolioWithItem(portfolioData, itemData)
   })
-});
-
-


### PR DESCRIPTION
**What:**
This PR adds Alerts for adding portfolios and fix missing `aria-label` prop for Button with plain variant.

**Screenshots:**
Adding new portfolio:
![before_cancel](https://user-images.githubusercontent.com/13417815/47432259-0b593380-d79e-11e8-855c-02155c45ebe5.png)
Cancel adding new portfolio:
![cancel](https://user-images.githubusercontent.com/13417815/47432260-0c8a6080-d79e-11e8-934a-1cc20013bfde.png)
Adding new portfolio failed:
![failed](https://user-images.githubusercontent.com/13417815/47432342-3b083b80-d79e-11e8-824f-2b32e933a43e.png)

**Note:**
For now, adding new portfolio is failing because portfolio items were removed, and this is not related to adding Alerts.