### PR TITLE
Add ability to edit Portfolios

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -25,10 +25,10 @@ const Orders = asyncComponent(() => import('./SmartComponents/Order/Orders'));
 const AddPlatformForm = asyncComponent(() => import('./SmartComponents/AddPlatform/AddPlatformForm'));
 
 const paths = {
-    service_portal: '/service_portal',
+    service_portal: '/',
     addplatform:  '/addplatform',
-    platform_items: '/platform_items/:filter?',
-    portfolio_items: '/portfolio_items/:filter?',
+    platform_items: '/platform_items/:id',
+    portfolio_items: '/portfolio_items/:id',
     orders: '/orders',
     admin: '/admin'
 };

--- a/src/SmartComponents/ServicePortal/PortalNav.js
+++ b/src/SmartComponents/ServicePortal/PortalNav.js
@@ -1,20 +1,22 @@
-import React from 'react';
+import React, { Component }  from 'react';
 import propTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
+import { withRouter, NavLink } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { Main } from '@red-hat-insights/insights-frontend-components';
 import { Nav, NavList, NavGroup, NavItem } from '@patternfly/react-core';
-import {bindMethods} from "../../Helpers/Shared/Helper";
+import { bindMethods } from "../../Helpers/Shared/Helper";
 import { fetchPlatforms } from '../../Store/Actions/PlatformActions';
 import { fetchPortfolios } from "../../Store/Actions/PortfolioActions";
+import { toggleEdit } from "../../Store/Actions/UiActions";
+import { PencilAltIcon } from '@patternfly/react-icons';
+import { Alert } from '@patternfly/react-core';
+import './portalnav.scss'
 
 
-class PortalNav extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            activeItem: 0
-        };
+class PortalNav extends Component {
+    state = {
+        activeItem: 0,
+        isEditing: false
     };
 
     componentDidMount() {
@@ -28,46 +30,59 @@ class PortalNav extends React.Component {
         this.props.fetchPortfolios();
     }
 
-    platformNavItems() {
-        return (
-            this.props.platforms.map(item => {
-                let itemLink=`/insights/platform/service_portal/platform_items/platform=${item.id}?`;
-                return (<NavItem to={itemLink} key={item.id}
-                    isActive={this.state.activeItem === item.id}>
-                    {item.name}
-                </NavItem>);})
-        );
-    };
+    platformNavItems = () => this.props.platforms.map(item => (
+      <NavItem
+        key={item.id}
+        itemId={item.id}
+        groupId="platforms"
+        activeClassName="pf-m-current"
+      >
+        <NavLink to={`/platform_items/${item.id}`}>
+          {item.name}
+        </NavLink>
+      </NavItem>
+    ));
 
-    portfolioNavItems() {
-        return (
-            this.props.portfolios.map(item => {
-                let itemLink=`/insights/platform/service_portal/portfolio_items/portfolio=${item.id}?`;
-                return (<NavItem to={itemLink} key={item.id}
-                    isActive={this.state.activeItem === item.id}>
-                    {item.name}
-                </NavItem>);})
-        );
-    };
+    portfolioNavItems = () => this.props.portfolios.map(item => (
+      <NavItem
+        key={item.id}
+        itemId={item.id}
+        groupId="portfolios"
+        isActive={this.state.activeItem === item.id && this.state.activeGroup === 'portfolios'}
+        className="portalnav"
+      >
+        <NavLink to={`/portfolio_items/${item.id}`} activeClassName="pf-m-current">
+          {item.name}
+          <span
+            onClick={this.props.toggleEdit}
+            className={this.props.location.pathname === `/portfolio_items/${item.id}` ? '' : 'editable-item'}
+            style={{float: 'right'}}
+          >
+            Edit {' '}
+            <PencilAltIcon />
+          </span>
+        </NavLink>
+      </NavItem>
+    ));
 
-    onSelect(result) {
-        this.setState({
-            activeItem: result.itemId
-        });
-    };
+    onSelect = ({ itemId, groupId }) => this.setState({
+        activeItem: itemId,
+        activeGroup: groupId
+    });
 
     render() {
         return (
             <Nav onSelect={this.onSelect} aria-label="Service Portal">
                 <NavGroup title="Platforms">
-                    { !this.props.isPlatformDataLoading &&
-              this.platformNavItems()}
+                    { !this.props.isPlatformDataLoading && this.platformNavItems()}
                 </NavGroup>
                 <NavGroup title="Portfolios">
-                    <NavItem to="/insights/platform/service_portal/portfolio_items" key="allPortfolios" isActive={this.state.activeItem === 'allPortfolios'}>
-              All Portfolios
-                    </NavItem>
-                    { !this.props.isLoading && this.portfolioNavItems()}
+                  <NavItem className="portalnav" groupId="portfolios">
+                    <NavLink key="allPortfolios" exact to="/" activeClassName="pf-m-current">
+                       All Portfolios
+                    </NavLink>
+                  </NavItem>
+                  { !this.props.isLoading && this.portfolioNavItems()}
                 </NavGroup>
             </Nav>
         );
@@ -88,6 +103,7 @@ const mapDispatchToProps = dispatch => {
     return {
         fetchPlatforms: () => dispatch(fetchPlatforms()),
         fetchPortfolios: () => dispatch(fetchPortfolios()),
+        toggleEdit: () => dispatch(toggleEdit())
     };
 };
 

--- a/src/SmartComponents/ServicePortal/portalnav.scss
+++ b/src/SmartComponents/ServicePortal/portalnav.scss
@@ -1,0 +1,12 @@
+@import "../../App";
+@import '~@red-hat-insights/insights-frontend-components/Utilities/_all';
+
+.editable-item {
+    visibility: hidden;
+}
+
+.portalnav:hover {
+	.editable-item {
+		visibility: initial;
+	}
+}

--- a/src/Store/ActionTypes/UiActionTypes.js
+++ b/src/Store/ActionTypes/UiActionTypes.js
@@ -1,0 +1,3 @@
+const prefix = '@@service-portal/ui/'
+
+export const TOGGLE_EDIT_SERVICE_PORTAL_ITEM = `${prefix}toggle-edit`

--- a/src/Store/Actions/UiActions.js
+++ b/src/Store/Actions/UiActions.js
@@ -1,0 +1,9 @@
+import { TOGGLE_EDIT_SERVICE_PORTAL_ITEM } from '../ActionTypes/UiActionTypes'
+import ReducerRegistry from '../../Utilities/ReducerRegistry';
+import UiReducer from '../Reducers/UiReducer';
+
+ReducerRegistry.register({ UiReducer });
+
+export const toggleEdit = () => ({
+    type: TOGGLE_EDIT_SERVICE_PORTAL_ITEM
+})

--- a/src/Store/Reducers/UiReducer.js
+++ b/src/Store/Reducers/UiReducer.js
@@ -1,0 +1,16 @@
+import { TOGGLE_EDIT_SERVICE_PORTAL_ITEM } from '../ActionTypes/UiActionTypes'
+
+const initialState = {
+   isEditing: false
+}
+
+const uiReducer = (state = initialState, action) => {
+    switch (action.type) {
+    	case TOGGLE_EDIT_SERVICE_PORTAL_ITEM: {
+    		return {...state, isEditing: !state.isEditing}
+    	}
+    }
+    return state
+}
+
+export default uiReducer


### PR DESCRIPTION
**What:**
Add _Edit_ icon for any portfolio displayed while hovering on portfolios name in the list of Portfolios, add new action, action type, Ui reducer (we need to know if we are editing the portfolio or not), support React routing, some other small changes.

**Screenshots:**
_All Portfolios_ are selected and _Edit_ icon appears next to some portfolio if we hover on the it:
![hover](https://user-images.githubusercontent.com/13417815/48136984-5183bc00-e2a1-11e8-9864-5eacd3c7feb0.png)
Clicking on _Edit_ to edit the portfolio (the portfolio becomes selected):
![click_edit](https://user-images.githubusercontent.com/13417815/48136992-53e61600-e2a1-11e8-8960-dff5179880ba.png)
If we click anywhere else, the portfolio remains selected (we will want to click on _Cancel_ to stop editing portfolio - this will coming soon in the next PR):
![click_anywhere](https://user-images.githubusercontent.com/13417815/48136999-55174300-e2a1-11e8-8149-8c4563ae8c8f.png)

**Next:**
In the next PR, I will add _Remove_ and _Cancel_ buttons which should appear if clicking on _Edit_ the portfolio from the list of portfolios, above the portfolio items.
