### PR TITLE
Replace data driven form in add portfolio modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": false,
   "dependencies": {
     "@babel/runtime": "^7.1.2",
+    "@data-driven-forms/pf4-component-mapper": "^0.3.0",
+    "@data-driven-forms/react-form-renderer": "^1.4.2",
     "@patternfly/patternfly-next": "^1.0.95",
     "@patternfly/react-core": "^1.38.5",
     "@patternfly/react-icons": "^2.4.0",

--- a/src/SmartComponents/Common/AddPortfolioModal.js
+++ b/src/SmartComponents/Common/AddPortfolioModal.js
@@ -7,7 +7,7 @@ import { Main, PageHeader, PageHeaderTitle } from '@red-hat-insights/insights-fr
 import { addPortfolioWithItem, fetchPortfolios } from '../../Store/Actions/PortfolioActions';
 import { PortfolioStore } from '../../Store/Reducers/PortfolioStore';
 import { consoleLog } from '../../Helpers/Shared/Helper';
-import { FormRenderer } from '@red-hat-insights/insights-frontend-components/components/Forms';
+import DataDrivenForm from './DataDrivenForm'
 import { addAlert, removeAlert } from '../../Store/Actions/AlertActions';
 
 const schema = {
@@ -60,9 +60,11 @@ class AddPortfolioModal extends Component {
                       </PageHeader>
                   </div>
                   <div className="pf-l-stack">
-                      <FormRenderer schema={ schema }
-                          onSubmit={ this.onSubmit }
-                          onCancel={ this.onCancel } />
+                      <DataDrivenForm
+                        schemaType="mozilla"
+                        schema={ schema }
+                        onSubmit={ this.onSubmit }
+                        onCancel={ this.onCancel } />
                   </div>
               </div>
           </Main>

--- a/src/SmartComponents/Common/DataDrivenForm.js
+++ b/src/SmartComponents/Common/DataDrivenForm.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import FormRender from '@data-driven-forms/react-form-renderer';
+import { formFieldsMapper, layoutMapper } from '@data-driven-forms/pf4-component-mapper';
+import PropTypes from 'prop-types';
+
+const DataDrivenForm = ({
+	componentMapper,
+	...rest
+}) => (
+  <FormRender
+    formFieldsMapper={{
+    	...formFieldsMapper,
+    	componentMapper,
+    }}
+    layoutMapper={layoutMapper}
+    {...rest}
+  />
+);
+
+DataDrivenForm.propTypes = {
+    schema: PropTypes.object.isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    onCancel: PropTypes.func
+}
+
+export default DataDrivenForm;


### PR DESCRIPTION
**What:**
This PR simply replaces data driven form with the one one.
Added a wrapper for it.

**More:**
https://github.com/data-driven-forms/pf4-component-mapper
https://github.com/data-driven-forms/react-form-renderer