### PR TITLE
Use react routing.

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -27,8 +27,8 @@ const Orders = asyncComponent(() => import('./SmartComponents/Order/Orders'));
 
 const paths = {
     service_portal: '/',
-    platform_items: '/platform_items/:filter?',
-    portfolio_items: '/portfolio_items/:filter?',
+    platform_items: '/platform_items/:id',
+    portfolio_items: '/portfolio_items/:id',
     portfolios: '/portfolios',
     portfolio: '/portfolios/:id',
     orders: '/orders'
@@ -38,13 +38,13 @@ type Props = {
     childProps: any
 };
 
-const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
+const InsightsRoute = ({ rootClass, ...rest }) => {
     const root = document.getElementById('root');
     root.removeAttribute('class');
     root.classList.add(`page__${rootClass}`, 'pf-l-page__main');
     root.setAttribute('role', 'main');
 
-    return (<Component { ...rest } />);
+    return (<Route { ...rest } />);
 };
 
 InsightsRoute.propTypes = {
@@ -65,10 +65,10 @@ export const Routes = (props: Props) => {
     return (
         <Switch>
             <InsightsRoute exact path={ paths.service_portal } component={ ServicePortal } rootClass="service_portal" />
-            <InsightsRoute exact path={ paths.platform_items } component={ PlatformItems } rootClass="platform_items" />
+            <InsightsRoute path={ paths.platform_items } component={ PlatformItems } rootClass="platform_items" />
             <InsightsRoute exact path={ paths.portfolio_items } component={ PortfolioItems } rootClass="portfolio_items" />
             <InsightsRoute exact path={ paths.portfolios } component={ Portfolios } rootClass="portfolios" />
-            <InsightsRoute exact path={ paths.portfolio } component={ Portfolio } rootClass="portfolio" />
+            <InsightsRoute path={ paths.portfolio } component={ Portfolio } rootClass="portfolio" />
             <InsightsRoute exact path={ paths.orders } component={ Orders } rootClass="service_portal" />
             { /* Finally, catch all unmatched routes */ }
             <Route render={ () => (some(paths, p => p === path) ? null : <Redirect to={ paths.service_portal } />) } />

--- a/src/SmartComponents/Platform/PlatformItems.js
+++ b/src/SmartComponents/Platform/PlatformItems.js
@@ -26,11 +26,13 @@ class PlatformItems extends Component {
     }
 
     componentDidMount() {
-        let filter = this.props.computedMatch.params.filter;
-        consoleLog('PlatformItems filter: ', filter);
-        let parsed = parse(filter);
-        consoleLog('PlatformItems parsed filter: ', parsed);
-        this.fetchData(parsed);
+        this.fetchData(this.props.match.params.id);
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.match.params.id !== this.props.match.params.id) {
+            this.fetchData(this.props.match.params.id);
+        }
     }
 
     renderToolbar() {

--- a/src/SmartComponents/Portfolio/Portfolio.js
+++ b/src/SmartComponents/Portfolio/Portfolio.js
@@ -33,9 +33,13 @@ class Portfolio extends Component {
     }
 
     componentDidMount() {
-        let portfolioId = this.props.computedMatch.params.id;
-        consoleLog('Portfolio Id: ', portfolioId);
-        this.fetchData(portfolioId);
+        this.fetchData(this.props.match.params.id);
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.match.params.id !== this.props.match.params.id) {
+            this.fetchData(this.props.match.params.id);
+        }
     }
 
     onKebabToggle = isOpen => {

--- a/src/SmartComponents/Portfolio/PortfolioItems.js
+++ b/src/SmartComponents/Portfolio/PortfolioItems.js
@@ -31,11 +31,12 @@ class PortfolioItems extends Component {
     }
 
     componentDidMount() {
-        let filter = this.props.computedMatch.params.filter;
-        consoleLog('PortfolioItems filter: ', filter);
-        let parsed = parse(filter);
-        consoleLog('PortfolioItems parsed filter: ', parsed);
-        this.fetchData(parsed);
+        this.fetchData(this.props.match.params.id);
+    }
+    componentDidUpdate(prevProps) {
+        if  (prevProps.match.params.id !== this.props.match.params.id) {
+            this.fetchData(this.props.match.params.id);
+        }
     }
 
     renderToolbar() {

--- a/src/SmartComponents/ServicePortal/PortalNav.js
+++ b/src/SmartComponents/ServicePortal/PortalNav.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
+import { withRouter, NavLink } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { bindMethods } from '../../Helpers/Shared/Helper';
 import { Nav, NavGroup, NavItem } from '@patternfly/react-core';
@@ -9,9 +9,9 @@ import { fetchPortfolios } from '../../Store/Actions/PortfolioActions';
 import { toggleEdit } from '../../Store/Actions/UiActions';
 import './portalnav.scss';
 
-const ALL_PORTFOLIOS_URL = '/insights/platform/service-portal/portfolios';
-const PLATFORM_ITEM_URL_BASE = `/insights/platform/service-portal/platform_items/platform=`;
-const PORTFOLIO_URL_BASE = `/insights/platform/service-portal/portfolios/`;
+const ALL_PORTFOLIOS_URL = '/portfolios';
+const PLATFORM_ITEM_URL_BASE = `/platform_items`;
+const PORTFOLIO_URL_BASE = `/portfolios`;
 
 class PortalNav extends React.Component {
     state = {
@@ -25,7 +25,7 @@ class PortalNav extends React.Component {
         bindMethods(this, [ 'onSelect' ]);
     }
 
-    fetchData() {
+    fetchData = () => {
     // TODO - only call if the user is an admin
         this.props.fetchPlatforms();
         this.props.fetchPortfolios();
@@ -34,13 +34,14 @@ class PortalNav extends React.Component {
     platformNavItems = () => {
         if (this.props.platforms) {
             return this.props.platforms.map(item => (
-                <NavItem key={ item.id }
-                    itemId={ item.id }
-                    groupId="platforms"
-                    to={ PLATFORM_ITEM_URL_BASE + `${item.id}` }
-                >
-                    { item.name }
-                </NavItem>
+                <NavLink key={ item.id } to={ `${PLATFORM_ITEM_URL_BASE}/${item.id}` }>
+                    <NavItem
+                        itemId={ item.id }
+                        groupId="platforms"
+                    >
+                        { item.name }
+                    </NavItem>
+                </NavLink>
             ));
         }
         else {
@@ -51,13 +52,13 @@ class PortalNav extends React.Component {
     portfolioNavItems = () => {
         if (this.props.portfolios) {
             return this.props.portfolios.map(item => (
-                <NavItem
-                    key={ item.id }
-                    groupId="portfolios"
-                    to={ PORTFOLIO_URL_BASE + `${item.id}` }
-                >
-                    { item.name }
-                </NavItem>
+                <NavLink key={ item.id } to={ `${PORTFOLIO_URL_BASE}/${item.id}` }>
+                    <NavItem
+                        groupId="portfolios"
+                    >
+                        { item.name }
+                    </NavItem>
+                </NavLink>
             ));
         } else {
             return null;
@@ -75,13 +76,14 @@ class PortalNav extends React.Component {
                 { !this.props.isPlatformDataLoading && this.platformNavItems() }
             </NavGroup>
             <NavGroup title="Portfolios">
-                <NavItem
-                    key='all'
-                    groupId="portfolios"
-                    to={ ALL_PORTFOLIOS_URL }
-                >
-                    All Portfolios
-                </NavItem>
+                <NavLink to={ ALL_PORTFOLIOS_URL }>
+                    <NavItem
+                        key='all'
+                        groupId="portfolios"
+                    >
+                        All Portfolios
+                    </NavItem>
+                </NavLink>
                 { !this.props.isLoading && this.portfolioNavItems() }
             </NavGroup>
         </Nav>;


### PR DESCRIPTION
Fixes issues with routes redirecting to root route and also adds client-side ui routing.

The route path is defined like this `/platform_items/:filter?`
But the link redirects you to this: `foo.redhat.com:1337/insights/platform/service-portal/platform_items/platform=1`

The router expects this string: `/platform_items/1`, but it gets `platform_items/platform=1`

Also routes where you expect changes in params cannot be marked as `exact` because the route will be changing by definition.

Also i have removed optional parameters from some routes, because there is no fallback component for case thet you did not provide params (all components expect id parameters to exist). Now the root route will be used instead.