### PR TITLE
Removed APP history listener.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,10 +15,13 @@ class App extends Component {
     componentDidMount () {
         insights.chrome.init();
         insights.chrome.identifyApp('service-portal');
-        insights.chrome.navigation(buildNavigation());
 
-        this.appNav = insights.chrome.on('APP_NAVIGATION', event => this.props.history.push(`/${event.navId}`));
-        this.buildNav = this.props.history.listen(() => insights.chrome.navigation(buildNavigation()));
+        this.appNav = insights.chrome.on('APP_NAVIGATION', event => {
+            /**
+             * This breaks navigation on first load it adds /path/undefined to URL and cause router to fallback to '/'
+             */
+            //this.props.history.push(`/${event.navId}`);
+        });
     }
 
     componentWillUnmount () {
@@ -55,8 +58,3 @@ App.propTypes = {
  *          https://reactjs.org/docs/higher-order-components.html
  */
 export default withRouter (connect()(App));
-
-function buildNavigation () {
-    const currentPath = window.location.pathname.split('/').slice(-1)[0];
-    return [];
-}


### PR DESCRIPTION
For some reason after the `App` component is mounted, it pushes some url to history. Pushed location was invalid and it was causing redirect to root route. I've commented it right now and will investigate further.