### PR TITLE
Added routing for portfolio actions.

### DIFF
--- a/src/PresentationalComponents/Portfolio/AddProductsTitleToolbar.js
+++ b/src/PresentationalComponents/Portfolio/AddProductsTitleToolbar.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import propTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import { Toolbar, ToolbarGroup, ToolbarItem, Title, Button } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import spacingStyles from '@patternfly/patternfly-next/utilities/Spacing/spacing.css';
 import flexStyles from '@patternfly/patternfly-next/utilities/Flex/flex.css';
 import '../../SmartComponents/Portfolio/portfolio.scss';
 
-const AddProductsTitleToolbar = ({ title, onClickCancelAddProducts, onClickAddToPortfolio }) =>(
+const AddProductsTitleToolbar = ({ title, onClickAddToPortfolio, portfolioRoute }) =>(
   <Toolbar
     className={ css(flexStyles.justifyContentSpaceBetween, spacingStyles.mxXl, spacingStyles.myMd) }
     style={ { backgroundColor: '#FFFFFF' } }
@@ -18,9 +19,11 @@ const AddProductsTitleToolbar = ({ title, onClickCancelAddProducts, onClickAddTo
     </ToolbarGroup>
     <ToolbarGroup className={ 'pf-u-ml-auto-on-xl' }>
       <ToolbarItem className={ css(spacingStyles.mxLg) }>
-        <Button variant="link" aria-label="Cancel Add Products to Portfolio" onClick={ onClickCancelAddProducts }>
-          Cancel
-        </Button>
+        <Link to={ portfolioRoute }>
+          <Button variant="link" aria-label="Cancel Add Products to Portfolio">
+            Cancel
+          </Button>
+        </Link>
       </ToolbarItem>
       <ToolbarItem className={ css(spacingStyles.mxLg) } >
         <Button variant="plain" aria-label="Add Products to Portfolio" onClick={ onClickAddToPortfolio }>
@@ -35,7 +38,7 @@ AddProductsTitleToolbar.propTypes = {
   history: propTypes.object,
   title: propTypes.string,
   onClickAddToPortfolio: propTypes.func,
-  onClickCancelAddProducts: propTypes.func
+  portfolioRoute: propTypes.string.isRequired
 };
 
 export default AddProductsTitleToolbar;

--- a/src/PresentationalComponents/Portfolio/PortfolioActionToolbar.js
+++ b/src/PresentationalComponents/Portfolio/PortfolioActionToolbar.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 import propTypes from 'prop-types';
 import { Toolbar, ToolbarGroup, ToolbarItem, DropdownItem, Dropdown, DropdownPosition, KebabToggle, Title, Button } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
@@ -50,9 +51,11 @@ class PortfolioActionToolbar extends Component {
           </ToolbarGroup>
           <ToolbarGroup className={ 'pf-u-ml-auto-on-xl' }>
             <ToolbarItem className={ css(spacingStyles.mxLg) }>
-              <Button variant="link" onClick={ this.props.onClickAddProducts }  aria-label="Add Products to Portfolio">
-                            Add Products
-              </Button>
+              <Link to={ this.props.addProductsRoute }>
+                <Button variant="link"  aria-label="Add Products to Portfolio">
+                  Add Products
+                </Button>
+              </Link>
             </ToolbarItem>
             <ToolbarItem className={ css(spacingStyles.mxLg) }>
               <Button variant="plain" aria-label="Remove Products from Portfolio">
@@ -69,10 +72,9 @@ class PortfolioActionToolbar extends Component {
 }
 
 PortfolioActionToolbar.propTypes = {
-  history: propTypes.object,
   title: propTypes.string,
   onClickEditPortfolio: propTypes.func,
-  onClickAddProducts: propTypes.func
+  addProductsRoute: propTypes.string.isRequired
 };
 
 export default PortfolioActionToolbar;

--- a/src/PresentationalComponents/Shared/404Route.js
+++ b/src/PresentationalComponents/Shared/404Route.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+/**
+ * Just a placeholder component. Will w8 for some designs.
+ */
+const NoMatch = () => (
+  <div>
+    <h1>
+      Page you are looking for does not exist.
+    </h1>
+  </div>
+);
+
+export default NoMatch;

--- a/src/SmartComponents/Portfolio/AddProductsToPortfolio.js
+++ b/src/SmartComponents/Portfolio/AddProductsToPortfolio.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { withRouter } from 'react-router-dom';
 import propTypes from 'prop-types';
 import { Section } from '@red-hat-insights/insights-frontend-components';
 import { addNotification } from '@red-hat-insights/insights-frontend-components/components/Notifications';
@@ -13,7 +14,7 @@ import PortfolioOrderToolbar from '../../PresentationalComponents/Portfolio/Port
 import AddProductsTitleToolbar from '../../PresentationalComponents/Portfolio/AddProductsTitleToolbar';
 import PlatformDashboard from '../../PresentationalComponents/Platform/PlatformDashboard';
 import PlatformSelectToolbar from '../../SmartComponents/Common/PlatformSelectToolbar';
-import { addToPortfolio } from '../../redux/Actions/PortfolioActions';
+import { addToPortfolio, fetchPortfolioItemsWithPortfolio } from '../../redux/Actions/PortfolioActions';
 import PlatformItem from '../../PresentationalComponents/Platform/PlatformItem';
 
 class AddProductsToPortfolio extends Component {
@@ -50,7 +51,8 @@ class AddProductsToPortfolio extends Component {
 
     onAddToPortfolio = () =>
       this.props.addToPortfolio(this.props.portfolio.id, this.state.checkedItems)
-      .then(() => this.props.resetViewMode(null, true));
+      .then(() => this.props.history.push(this.props.portfolioRoute))
+      .then(() => this.props.fetchPortfolioItemsWithPortfolio(this.props.match.params.id));
 
     render() {
       let filteredItems = [];
@@ -74,7 +76,8 @@ class AddProductsToPortfolio extends Component {
           <PortfolioOrderToolbar/>
           <AddProductsTitleToolbar title={ title }
             onClickAddToPortfolio = { this.onAddToPortfolio }
-            onClickCancelAddProducts={ this.props.resetViewMode }/>
+            portfolioRoute={ this.props.portfolioRoute }
+          />
           <PlatformSelectToolbar onOptionSelect={ this.onPlatformSelectionChange } { ...this.props } />
           { (this.state.selectedPlatforms.length > 0) &&
                     this.state.selectedPlatforms.map((platform)=> {return (<ContentGallery key={ platform.id } { ...filteredItems }
@@ -98,7 +101,8 @@ const mapStateToProps = ({ platformReducer: { platformItems, isPlatformDataLoadi
 const mapDispatchToProps = dispatch => bindActionCreators({
   addNotification,
   fetchPlatformItems,
-  addToPortfolio
+  addToPortfolio,
+  fetchPortfolioItemsWithPortfolio
 }, dispatch);
 
 AddProductsToPortfolio.propTypes = {
@@ -106,12 +110,21 @@ AddProductsToPortfolio.propTypes = {
   isLoading: propTypes.bool,
   isEditMode: propTypes.bool,
   addToPortfolio: propTypes.func,
-  resetViewMode: propTypes.func,
   fetchPlatformItems: propTypes.func,
   portfolio: propTypes.shape({
     name: propTypes.string,
     id: propTypes.oneOfType([ propTypes.string, propTypes.number ]).isRequired
-  }).isRequired
+  }).isRequired,
+  history: propTypes.shape({
+    push: propTypes.func.isRequired
+  }).isRequired,
+  match: propTypes.shape({
+    params: propTypes.shape({
+      id: propTypes.string.isRequired
+    }).isRequired
+  }).isRequired,
+  portfolioRoute: propTypes.string.isRequired,
+  fetchPortfolioItemsWithPortfolio: propTypes.func.isRequired
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(AddProductsToPortfolio);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(AddProductsToPortfolio));

--- a/src/redux/Actions/PortfolioActions.js
+++ b/src/redux/Actions/PortfolioActions.js
@@ -57,7 +57,16 @@ export const addPortfolio = (portfolioData, items) => ({
 
 export const addToPortfolio = (portfolioId, items) => ({
   type: ActionTypes.ADD_TO_PORTFOLIO,
-  payload: PortfolioHelper.addToPortfolio(portfolioId, items)
+  payload: PortfolioHelper.addToPortfolio(portfolioId, items),
+  meta: {
+    notifications: {
+      fulfilled: {
+        variant: 'success',
+        title: 'Success adding products',
+        description: 'Products were successfully added to portfolio.'
+      }
+    }
+  }
 });
 
 export const updatePortfolio = (portfolioData) => ({


### PR DESCRIPTION
Switching between views for list of portfolio products and add products to portfolio was handled via react state. That is probably not something we want.

I've replaced it with react routing so the user is not redirected to different page after refresh and we can use history.

I've also noticed that we use something similar for add/edit modals. I think we should also add routing to these. We will be able to simplify all components using `MainModal` component and Remove the MainModal reducer. That is for future PR. 

