### PR TITLE
Added pf react tokens to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@patternfly/patternfly-next": "^1.0.95",
     "@patternfly/react-core": "^1.43.2",
     "@patternfly/react-icons": "^2.4.0",
+    "@patternfly/react-tokens": "^1.9.6",
     "@red-hat-insights/insights-frontend-components": "^3.28.0",
     "font-awesome": "^4.7.0",
     "lodash": "^4.17.10",


### PR DESCRIPTION
Fixes build error `Uncaught Error: Cannot find module '@patternfly/react-tokens'`

This occurs after updating PF version. They have changed they build in minor release once again.