### PR TITLE
Added error message keys to notifications configuration.

### DIFF
--- a/src/Utilities/store.js
+++ b/src/Utilities/store.js
@@ -11,7 +11,10 @@ import platformReducer, { platformInitialState } from '../redux/reducers/platfor
 import portfolioReducer, { portfoliosInitialState } from '../redux/reducers/portfolioReducer';
 import uiReducer, { uiInitialState } from '../redux/reducers/UiReducer';
 
-const registry = new ReducerRegistry({}, [ promiseMiddleware(), notificationsMiddleware(), thunk, reduxLogger ]);
+const registry = new ReducerRegistry({}, [ promiseMiddleware(), notificationsMiddleware({
+  errorTitleKey: [ 'message' ],
+  errorDescriptionKey: [ 'errors', 'stack' ]
+}), thunk, reduxLogger ]);
 
 registry.register({
   mainModalReducer: applyReducerHash(mainModalReducer, mainModalInitialState),


### PR DESCRIPTION
Adds keys to automatic error notification. We can now start removing manual handling of error messages for API requests.

- SSP API (errors)
- low level javascript error message (message, stack)

We can add more in the future for other APIs (when we know what error format we get.)