### PR TITLE
Add graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@patternfly/react-tokens": "^1.9.6",
     "@red-hat-insights/insights-frontend-components": "^3.28.0",
     "font-awesome": "^4.7.0",
+    "graphql": "^14.0.2",
     "lodash": "^4.17.10",
     "patternfly-react": "^2.13.1",
     "react": "^16.7.0",


### PR DESCRIPTION
Error on dev cluster :

Error: Cannot use e "__Schema" from another module or realm. Ensure that there is only one instance of "graphql" in the node_modules directory. If different versions of "graphql" are the dependencies of other relied on modules, use "resolutions" to ensure only one version is installed. https://yarnpkg.com/en/docs/selective-version-resolutions Duplicate "graphql" modules cannot be used at the same time since different versions may have different capabilities and behavior. The data from one version used in the function from another could produce confusing and spurious results.
