### PR TITLE
Fixed header generating form orders table.

### DIFF
--- a/src/SmartComponents/ContentGallery/ContentList.js
+++ b/src/SmartComponents/ContentGallery/ContentList.js
@@ -4,44 +4,46 @@ import { PageHeader, PageHeaderTitle, Table, Section } from '@red-hat-insights/i
 import { Bullseye } from '@patternfly/react-core';
 
 const ContentList = ({ isLoading, items }) => {
-  if (isLoading || (items && items.length > 0)) {
-    if (items && items.length > 0)
-    {
-      items.sort(function (a, b) {
-        let dateA = new Date(a.created_at);
-        let dateB = new Date(b.created_at);
-        return dateB - dateA; //sort by date descending
-      });
-    };
 
+  if (isLoading)
+  {
     return (
-      <React.Fragment>
-        <br />
-        <Bullseye>
-          <div>
-            { isLoading && (<span color={ '#00b9e4' }> Loading...</span>) }
-          </div>
-        </Bullseye>
-        <Section type='content'>
-          { (items && items.length > 0) && (
-            <Table
-              header={ Object.keys(items[0]) }
-              rows={ items.map(item => {
-                let row = {};
-                row.cells = (Object.values(item)).map(val => val === undefined ? '' : val.toString());
-                return row;
-              }) }
-            />)
-          }
-        </Section>
-      </React.Fragment>
+      <PageHeader>
+        <PageHeaderTitle title={ 'No Orders' }/>
+      </PageHeader>
     );
   }
 
+  if (items && items.length > 0) {
+    items.sort(function (a, b) {
+      let dateA = new Date(a.created_at);
+      let dateB = new Date(b.created_at);
+      return dateB - dateA; //sort by date descending
+    });
+  }
+
+  const headers = items.reduce((acc, curr) => Object.keys(curr).length > acc.length ? Object.keys(curr) : acc,  []);
   return (
-    <PageHeader>
-      <PageHeaderTitle title={ 'No Orders' }/>
-    </PageHeader>
+    <React.Fragment>
+      <br />
+      <Bullseye>
+        <div>
+          { isLoading && (<span color={ '#00b9e4' }> Loading...</span>) }
+        </div>
+      </Bullseye>
+      <Section type='content'>
+        { (items && items.length > 0) && (
+          <Table
+            header={ headers }
+            rows={ items.map(item => {
+              let row = {};
+              row.cells = (Object.values(item)).map(val => val === undefined ? '' : val.toString());
+              return row;
+            }) }
+          />)
+        }
+      </Section>
+    </React.Fragment>
   );
 };
 


### PR DESCRIPTION
There was an error in runtime when rendering orders table:

![screenshot from 2019-01-24 10-18-45](https://user-images.githubusercontent.com/22619452/51668723-24eb6080-1fc3-11e9-9d9c-78239a0fcc88.png)


This was caused by faulty table header generator. It assumed that the first order will always have all the columns defined. If that is not a case the table body will be rendered fine. But if some row has additional data, it will reference header column that does not exist at ui will crash.

I've created header generator that will always create headers from row with largest amount of columns. 

Note, that this is not exactly clean approach, but because i plan to migrate to PF4 table component soon i will create better way to define the table contents then.

Also the loader placeholder was in wrong code branch.
