### PR TITLE
Cleanup unused env vars and rename for clarity

### DIFF
--- a/config/base.webpack.plugins.js
+++ b/config/base.webpack.plugins.js
@@ -87,14 +87,7 @@ plugins.push(CopyFilesWebpackPlugin);
  * Makes build-time env vars available to the client-side as constants
  */
 const envPlugin = new webpack.DefinePlugin({
-    'process.env.API_HOST': JSON.stringify(process.env.API_HOST),
-    'process.env.API_PORT': JSON.stringify(process.env.API_PORT),
-    'process.env.BASE_PATH': JSON.stringify(process.env.BASE_PATH),
-    'process.env.API_VERSION': JSON.stringify(process.env.API_VERSION),
-    'process.env.TOPO_API_HOST': JSON.stringify(process.env.TOPO_API_HOST),
-    'process.env.TOPO_API_PORT': JSON.stringify(process.env.TOPO_API_PORT),
-    'process.env.TOPO_BASE_PATH': JSON.stringify(process.env.TOPO_BASE_PATH),
-    'process.env.TOPO_API_VERSION': JSON.stringify(process.env.TOPO_API_VERSION)
+    'process.env.BASE_PATH': JSON.stringify(process.env.BASE_PATH || '/r/insights/platform')
 });
 plugins.push(envPlugin);
 

--- a/src/Helpers/Shared/userLogin.js
+++ b/src/Helpers/Shared/userLogin.js
@@ -1,11 +1,11 @@
 import { AdminsApi, ApiClient as ServicePortalApiClient } from '@manageiq/service-portal-api';
 import { DefaultApi, ApiClient as TopologicalInventoryApiClient } from '@manageiq/topological_inventory';
-import { SOURCES_API_BASE, SERVICE_PORTAL_API_BASE } from '../../Utilities/Constants';
+import { TOPOLOGICAL_INVENTORY_API_BASE, SERVICE_PORTAL_API_BASE } from '../../Utilities/Constants';
 
 const adminApi = new AdminsApi();
 
 const defaultClient = TopologicalInventoryApiClient.instance;
-defaultClient.basePath = SOURCES_API_BASE;
+defaultClient.basePath = TOPOLOGICAL_INVENTORY_API_BASE;
 
 const sspDefaultClient = ServicePortalApiClient.instance;
 sspDefaultClient.basePath = SERVICE_PORTAL_API_BASE;

--- a/src/Utilities/Constants.js
+++ b/src/Utilities/Constants.js
@@ -1,3 +1,2 @@
-
-export const SOURCES_API_BASE = `/r/insights/platform/topological-inventory/v0.0`;
-export const SERVICE_PORTAL_API_BASE = `/r/insights/platform/service-portal/v0.0`;
+export const SERVICE_PORTAL_API_BASE = `${process.env.BASE_PATH}/service-portal/v0.0`;
+export const TOPOLOGICAL_INVENTORY_API_BASE = `${process.env.BASE_PATH}/topological-inventory/v0.0`;

--- a/src/test/redux/actions/portfolio-actions.test.js
+++ b/src/test/redux/actions/portfolio-actions.test.js
@@ -18,6 +18,9 @@ import {
   updatePortfolio,
   removePortfolio
 } from '../../../redux/Actions/PortfolioActions';
+import {
+  SERVICE_PORTAL_API_BASE
+} from '../../../Utilities/Constants';
 
 describe('Portfolio actions', () => {
   const middlewares = [ thunk, promiseMiddleware(), notificationsMiddleware() ];
@@ -41,7 +44,7 @@ describe('Portfolio actions', () => {
       payload: [{ id: '1', name: 'foo' }]
     }];
 
-    apiClientMock.get('/r/insights/platform/service-portal/v0.0/portfolios', mockOnce({
+    apiClientMock.get(SERVICE_PORTAL_API_BASE + '/portfolios', mockOnce({
       body: [{
         id: '1',
         name: 'foo'
@@ -86,7 +89,7 @@ describe('Portfolio actions', () => {
 
     }) ]);
 
-    apiClientMock.get('/r/insights/platform/service-portal/v0.0/portfolios', mockOnce({
+    apiClientMock.get(SERVICE_PORTAL_API_BASE + '/portfolios', mockOnce({
       status: 500
     }));
 
@@ -99,7 +102,7 @@ describe('Portfolio actions', () => {
   it('should dispatch correct actions after fetchPortfolioItems action was called', () => {
     const store = mockStore({});
 
-    apiClientMock.get('/r/insights/platform/service-portal/v0.0/portfolio_items', mockOnce({
+    apiClientMock.get(SERVICE_PORTAL_API_BASE + '/portfolio_items', mockOnce({
       body: [{ data: 'foo' }]
     }));
 
@@ -119,7 +122,7 @@ describe('Portfolio actions', () => {
   it('should dispatch correct actions after fetchPortfolioItemsWithPortfolio action was called', () => {
     const store = mockStore({});
 
-    apiClientMock.get('/r/insights/platform/service-portal/v0.0/portfolios/123/portfolio_items', mockOnce({
+    apiClientMock.get(SERVICE_PORTAL_API_BASE + '/portfolios/123/portfolio_items', mockOnce({
       body: [{ data: 'foo' }]
     }));
 
@@ -138,7 +141,7 @@ describe('Portfolio actions', () => {
 
   it('should create correct action creators when adding portfolio', () => {
     const store = mockStore({});
-    apiClientMock.post('/r/insights/platform/service-portal/v0.0/portfolios', mockOnce({
+    apiClientMock.post(SERVICE_PORTAL_API_BASE + '/portfolios', mockOnce({
       body: [{ data: 'foo' }]
     }));
 
@@ -156,7 +159,7 @@ describe('Portfolio actions', () => {
 
   it('should create error action creators when adding portfolio failed', () => {
     const store = mockStore({});
-    apiClientMock.post('/r/insights/platform/service-portal/v0.0/portfolios', mockOnce({
+    apiClientMock.post(SERVICE_PORTAL_API_BASE + '/portfolios', mockOnce({
       status: 500
     }));
 
@@ -174,7 +177,7 @@ describe('Portfolio actions', () => {
 
   it('should create correct action creators when updating portfolio', () => {
     const store = mockStore({});
-    apiClientMock.patch('/r/insights/platform/service-portal/v0.0/portfolios/123', mockOnce({
+    apiClientMock.patch(SERVICE_PORTAL_API_BASE + '/portfolios/123', mockOnce({
       body: [{ data: 'foo' }]
     }));
 
@@ -192,7 +195,7 @@ describe('Portfolio actions', () => {
 
   it('should create correct action creators when updating portfolio failed', () => {
     const store = mockStore({});
-    apiClientMock.patch('/r/insights/platform/service-portal/v0.0/portfolios/123', mockOnce({
+    apiClientMock.patch(SERVICE_PORTAL_API_BASE + '/portfolios/123', mockOnce({
       status: 500
     }));
 
@@ -210,7 +213,7 @@ describe('Portfolio actions', () => {
 
   it('should create correct action creators when removing portfolio', () => {
     const store = mockStore({});
-    apiClientMock.delete('/r/insights/platform/service-portal/v0.0/portfolios/123', mockOnce({
+    apiClientMock.delete(SERVICE_PORTAL_API_BASE + '/portfolios/123', mockOnce({
       body: [{ data: 'foo' }]
     }));
 
@@ -228,7 +231,7 @@ describe('Portfolio actions', () => {
 
   it('should create correct action creators when removing portfolio faled', () => {
     const store = mockStore({});
-    apiClientMock.delete('/r/insights/platform/service-portal/v0.0/portfolios/123', mockOnce({
+    apiClientMock.delete(SERVICE_PORTAL_API_BASE + '/portfolios/123', mockOnce({
       status: 500
     }));
 


### PR DESCRIPTION
Additionally, use the BASE_PATH env var as part of the API paths

@martinpovolny @Hyperkid123 Please review.  Let's also discuss before merge because I need to change the travis environment to have BASE_PATH set properly (and less importantly, so I can remove the rest of the env vars defined there).