### PR TITLE
Added selection of destination project for order modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -861,17 +861,17 @@
       }
     },
     "@data-driven-forms/pf4-component-mapper": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-0.3.2.tgz",
-      "integrity": "sha512-NEVbEELIl6wKfBp/h0E+hHfUHqrmeT8G+dqDb3mOybN1nzl8q1cgQaBWmRfhRJPoMIq7SNtH9y6SJCn3wr4SRw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-0.4.1.tgz",
+      "integrity": "sha512-8+CS9Vz9PLBqc5NHlMgxW66UNBh51pURSIQvmtvIW4Tgsf95SejnkBKH5iuVNymSnef5ilxNHnGXxYWpCfkVKw==",
       "requires": {
         "@patternfly/patternfly-next": "^1.0.87"
       }
     },
     "@data-driven-forms/react-form-renderer": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-1.5.5.tgz",
-      "integrity": "sha512-lZvGJROzft9tkigxTRoe3tnCnAktrMC4SpSkI17oyAaXBPDEw6G0+m6SFCSnpx/4TJFVErDXwXBQq48cirL1Nw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-1.6.0.tgz",
+      "integrity": "sha512-es8g1wZWnz62xpRVIe97C7o7hhIK0ffP8UuYPVeOw7RBHS+8KyGroMNabTvXZrhlnhYvkhMxde0cMSdE6N7ntQ==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.1.0",
         "final-form": "^4.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -861,17 +861,17 @@
       }
     },
     "@data-driven-forms/pf4-component-mapper": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-0.4.1.tgz",
-      "integrity": "sha512-8+CS9Vz9PLBqc5NHlMgxW66UNBh51pURSIQvmtvIW4Tgsf95SejnkBKH5iuVNymSnef5ilxNHnGXxYWpCfkVKw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-0.3.2.tgz",
+      "integrity": "sha512-NEVbEELIl6wKfBp/h0E+hHfUHqrmeT8G+dqDb3mOybN1nzl8q1cgQaBWmRfhRJPoMIq7SNtH9y6SJCn3wr4SRw==",
       "requires": {
         "@patternfly/patternfly-next": "^1.0.87"
       }
     },
     "@data-driven-forms/react-form-renderer": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-1.6.0.tgz",
-      "integrity": "sha512-es8g1wZWnz62xpRVIe97C7o7hhIK0ffP8UuYPVeOw7RBHS+8KyGroMNabTvXZrhlnhYvkhMxde0cMSdE6N7ntQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-1.5.5.tgz",
+      "integrity": "sha512-lZvGJROzft9tkigxTRoe3tnCnAktrMC4SpSkI17oyAaXBPDEw6G0+m6SFCSnpx/4TJFVErDXwXBQq48cirL1Nw==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.1.0",
         "final-form": "^4.11.0",
@@ -12488,9 +12488,9 @@
       }
     },
     "parse-node-version": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.0.tgz",
-      "integrity": "sha512-02GTVHD1u0nWc20n2G7WX/PgdhNFG04j5fi1OkaJzPWLTcf6vh6229Lta1wTmXG/7Dg42tCssgkccVt7qvd8Kg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
     },
     "parse-passwd": {
       "version": "1.0.0",

--- a/src/Helpers/Portfolio/PortfolioHelper.js
+++ b/src/Helpers/Portfolio/PortfolioHelper.js
@@ -1,4 +1,5 @@
 import { getUserApi } from '../Shared/userLogin';
+import { SERVICE_PORTAL_API_BASE } from '../../Utilities/Constants';
 
 const userApi = getUserApi();
 
@@ -64,4 +65,19 @@ export async function removePortfolioItem(portfolioItemId) {
 
 export async function removePortfolioItems(portfolioItemIds) {
   return Promise.all(portfolioItemIds.map(async itemId => await removePortfolioItem(itemId)));
+}
+
+export function fetchProviderControlParameters(portfolioItemId) {
+  return fetch(`${SERVICE_PORTAL_API_BASE}/portfolio_items/${portfolioItemId}/provider_control_parameters`)
+  .then(data => data.json())
+  .then(data => ({
+    required: [],
+    ...data,
+    properties: {
+      ...data.properties,
+      namespace: {
+        ...data.properties.namespace,
+        enum: Array.from(new Set([ ...data.properties.namespace.enum ]))
+      }
+    }}));
 }

--- a/src/SmartComponents/Common/MainModal.js
+++ b/src/SmartComponents/Common/MainModal.js
@@ -46,8 +46,9 @@ class MainModalContainer extends React.Component {
     return (
       <div>
         <Modal isOpen={ this.props.modalProps.open }
-          id='mainModal' title={ this.props.title || '' }
-          className="modal-dialog modal-lg"
+          id='mainModal'
+          title={ this.props.title || '' }
+          style={ { width: 600 } }
           onClose={ this.closeModal }>
           <SpecifiedModal
             closeModal={ this.closeModal }

--- a/src/test/redux/actions/portfolio-actions.test.js
+++ b/src/test/redux/actions/portfolio-actions.test.js
@@ -37,16 +37,16 @@ describe('Portfolio actions', () => {
         isLoading: false
       }
     });
+    const expectedPortfolio = new Portfolio('Name', 'Description');
 
     const expectedActions = [{
       type: `${FETCH_PORTFOLIOS}_PENDING`
     }, {
       type: `${FETCH_PORTFOLIOS}_FULFILLED`,
-      payload: [ new Portfolio('name', 'description') ]
+      payload: [ expectedPortfolio ]
     }];
-
     apiClientMock.get(SERVICE_PORTAL_API_BASE + '/portfolios', mockOnce({
-      body: { data: [ new Portfolio('name', 'description') ]}
+      body: { data: [ expectedPortfolio ]}
     }));
 
     return store.dispatch(fetchPortfolios())


### PR DESCRIPTION
### Need info
- Are these supposed to show for every portfolio or only for some kind. If so, how can i tell when to make this request?
- Do we know where the select field should be? On the top/bottom somewhere else?
- Thanks to the nested structure of JSON schema, output data format of the for for the destination will be nested. What is the expected data format? Is it just a random object? Right now the generated docs does not specify how the data should look like.
```javascript
{
  name: 'Foo',
  description: 'Bar',
  providerControlParameters: {
    namespace: 'default'
  }
}
``` 

### Issues
- New API clients returns instances of classes. That will hurt us in a long run. Right now it enforces using classes in only tests. This would be fine if we are creating these objects in UI but everything is done via API and will add additional overhead.
- pf4 changes styling for multiple components. Modal and select are broken once again
- PF4 select component does not recognize empty value and will always select first option, but that will not update form state, that is why the select is in error state even when `default` (first) option is selected. And because we are using mozilla JSON schema which uses the enum with just values (not combo label, value) we cannot add some `Please Choose` option with empty(undefined) value.
- The helper function from API client for retrieving the schema is always empty object. It returns a readable stream that is not converted to JSON inside the API client. I had to use custom `fetch` request to return correct data. Making the API to return only plain JSON objects would fix this issue.
- Options for destination contain duplicate values. Created a SET from the array, that fixed the problem. But i think the API should not return duplicate values.


![dynamic-form](https://user-images.githubusercontent.com/22619452/52267663-f1e98b00-2939-11e9-89aa-0e19ebe83c73.gif)
