### PR TITLE
Non archived service offerings

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -2,6 +2,13 @@ import { configure, mount, render, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import mock, { once } from 'xhr-mock';
+import fetchMock from 'fetch-mock';
+
+/**
+ * mock fetch
+ */
+import 'whatwg-fetch';
+global.fetchMock = fetchMock;
 
 configure({ adapter: new Adapter() });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3227,6 +3227,17 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      }
+    },
     "babel-preset-fbjs": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.3.0.tgz",
@@ -7167,6 +7178,32 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        }
+      }
+    },
+    "fetch-mock": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.3.0.tgz",
+      "integrity": "sha512-KxBeS8vsADFbWPVomuwxYqOJ2obZo6CidgkypjDPeu6zl+tAJvh2GfLDmJ8u//xgBGM9iOGwOxafeqAclilH2A==",
+      "dev": true,
+      "requires": {
+        "babel-polyfill": "^6.26.0",
+        "glob-to-regexp": "^0.4.0",
+        "path-to-regexp": "^2.2.1",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "glob-to-regexp": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz",
+          "integrity": "sha512-fyPCII4vn9Gvjq2U/oDAfP433aiE64cyP/CJjRJcpVGjqqNdioUYn9+r0cSzT1XPwmGAHuTT7iv+rQT8u/YHKQ==",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+          "dev": true
         }
       }
     },
@@ -14650,6 +14687,12 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.13.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-select": "^2.1.2",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
-    "rxjs": "^6.3.3"
+    "rxjs": "^6.3.3",
+    "whatwg-fetch": "^3.0.0"
   },
   "sassIncludes": {
     "patternfly": "node_modules/patternfly/dist/sass",
@@ -68,6 +69,7 @@
     "eslint-config-prettier": "^2.10.0",
     "eslint-loader": "^2.1.0",
     "eslint-plugin-react": "^7.11.1",
+    "fetch-mock": "^7.3.0",
     "file-loader": "^1.1.11",
     "git-revision-webpack-plugin": "^3.0.3",
     "glob": "^7.1.3",

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,8 @@ import { Grid, GridItem } from '@patternfly/react-core';
 import { MIN_SCREEN_HEIGHT } from './constants/ui-constants';
 import '@red-hat-insights/insights-frontend-components/components/Notifications.css';
 
+import 'whatwg-fetch';
+
 class App extends Component {
   state = {
     chromeNavAvailable: true

--- a/src/Helpers/Platform/PlatformHelper.js
+++ b/src/Helpers/Platform/PlatformHelper.js
@@ -1,4 +1,5 @@
 import { getTopologicalUserApi } from '../Shared/userLogin';
+import { TOPOLOGICAL_INVENTORY_API_BASE } from '../../Utilities/Constants';
 
 const api = getTopologicalUserApi();
 
@@ -14,7 +15,7 @@ export function getPlatformItems(apiProps) {
   let apiPromise = null;
 
   if (apiProps) {
-    apiPromise = api.listSourceServiceOfferings(apiProps);
+    apiPromise = fetch(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/${apiProps}/service_offerings?archived_at=`).then(data => data.json());
   } else {
     apiPromise = api.listServiceOfferings();
   }

--- a/src/test/.eslintrc
+++ b/src/test/.eslintrc
@@ -5,6 +5,7 @@
   },
   "globals": {
     "apiClientMock": true,
-    "mockOnce": true
+    "mockOnce": true,
+    "fetchMock": true
   }
 }

--- a/src/test/redux/actions/platform-actions.test.js
+++ b/src/test/redux/actions/platform-actions.test.js
@@ -24,6 +24,10 @@ describe('Platform actions', () => {
     mockStore = configureStore(middlewares);
   });
 
+  afterEach(() => {
+    fetchMock.reset();
+  });
+
   it('should dispatch correct actions after fetching platforms', () => {
     const store = mockStore({
       platformReducer: {
@@ -96,12 +100,11 @@ describe('Platform actions', () => {
         isPlatformDataLoading: false
       }
     });
-    apiClientMock.get(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/1/service_offerings`, mockOnce({
-      body: { data: [{
-        id: '1',
-        name: 'Offering 1'
-      }]}
-    }));
+
+    fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/1/service_offerings?archived_at=`, { data: [{
+      id: '1',
+      name: 'Offering 1'
+    }]});
 
     const expectedActions = [{
       type: `${FETCH_PLATFORM_ITEMS}_PENDING`,
@@ -123,9 +126,8 @@ describe('Platform actions', () => {
         isPlatformDataLoading: false
       }
     });
-    apiClientMock.get(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/1/service_offerings`, mockOnce({
-      status: 500
-    }));
+
+    fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/1/service_offerings?archived_at=`, 500);
 
     const expectedActions = [
       {
@@ -149,24 +151,18 @@ describe('Platform actions', () => {
         isPlatformDataLoading: false
       }
     });
-    apiClientMock.get(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/1/service_offerings`, mockOnce({
-      body: { data: [{
-        id: '1',
-        name: 'Offering 1'
-      }]}
-    }));
-    apiClientMock.get(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/2/service_offerings`, mockOnce({
-      body: { data: [{
-        id: '2',
-        name: 'Offering 2'
-      }]}
-    }));
-    apiClientMock.get(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/3/service_offerings`, mockOnce({
-      body: { data: [{
-        id: '3',
-        name: 'Offering 3'
-      }]}
-    }));
+    fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/1/service_offerings?archived_at=`, { data: [{
+      id: '1',
+      name: 'Offering 1'
+    }]});
+    fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/2/service_offerings?archived_at=`, { data: [{
+      id: '2',
+      name: 'Offering 2'
+    }]});
+    fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/3/service_offerings?archived_at=`, { data: [{
+      id: '3',
+      name: 'Offering 3'
+    }]});
 
     const expectedActions = [{
       type: `${FETCH_MULTIPLE_PLATFORM_ITEMS}_PENDING`
@@ -190,21 +186,15 @@ describe('Platform actions', () => {
         isPlatformDataLoading: false
       }
     });
-    apiClientMock.get(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/1/service_offerings`, mockOnce({
-      body: [{
-        id: '1',
-        name: 'Offering 1'
-      }]
-    }));
-    apiClientMock.get(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/2/service_offerings`, mockOnce({
-      body: [{
-        id: '2',
-        name: 'Offering 2'
-      }]
-    }));
-    apiClientMock.get(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/3/service_offerings`, mockOnce({
-      status: 500
-    }));
+    fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/1/service_offerings?archived_at=`, { data: [{
+      id: '1',
+      name: 'Offering 1'
+    }]});
+    fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/2/service_offerings?archived_at=`, { data: [{
+      id: '2',
+      name: 'Offering 2'
+    }]});
+    fetchMock.getOnce(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/3/service_offerings?archived_at=`, 500);
 
     const expectedActions = [{
       type: `${FETCH_MULTIPLE_PLATFORM_ITEMS}_PENDING`


### PR DESCRIPTION
Requests for service offerings are now filtering out archived entities. This required a custom API call because API clients does not support filtering features yet.

### Changes
- custom API call for service offerings
- added polyfill for `fetch`: https://www.npmjs.com/package/whatwg-fetch
- adjusted tests to work with fetch API