### PR TITLE
Fixed unauthorized error

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,14 +12,17 @@ import { MIN_SCREEN_HEIGHT } from './constants/ui-constants';
 import '@red-hat-insights/insights-frontend-components/components/Notifications.css';
 
 import 'whatwg-fetch';
+import { AppPlaceholder } from './PresentationalComponents/Shared/LoaderPlaceholders';
 
 class App extends Component {
   state = {
-    chromeNavAvailable: true
+    chromeNavAvailable: true,
+    auth: false
   }
 
   componentDidMount () {
     insights.chrome.init();
+    insights.chrome.auth.getUser().then(() => this.setState({ auth: true }));
     try {
       insights.chrome.identifyApp('service-portal');
     } catch (error) {
@@ -37,6 +40,11 @@ class App extends Component {
   }
 
   render () {
+    const { auth } = this.state;
+    if (!auth) {
+      return <AppPlaceholder />;
+    }
+
     return (
       <React.Fragment>
         <NotificationsPortal />

--- a/src/PresentationalComponents/Shared/LoaderPlaceholders.js
+++ b/src/PresentationalComponents/Shared/LoaderPlaceholders.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ContentLoader from 'react-content-loader';
 import PropTypes from 'prop-types';
+import { Main } from '@red-hat-insights/insights-frontend-components';
 import { Card, CardBody, Grid, GridItem, NavItem } from '@patternfly/react-core';
 
 export const CardLoader = ({ items, ...props }) => (
@@ -90,7 +91,7 @@ NavLoader.defaultProps = {
 };
 
 export const AppPlaceholder = props => (
-  <div>
+  <Main style={ { marginLeft: 0, padding: 0 } }>
     <ContentLoader
       height={ 16 }
       width={ 300 }
@@ -101,5 +102,5 @@ export const AppPlaceholder = props => (
       <rect x="0" y="0" rx="0" ry="0" width="420" height="10" />
     </ContentLoader>
     <CardLoader />
-  </div>
+  </Main>
 );


### PR DESCRIPTION
Fixes issue with unauthorized error after login. 

### Issue
Chrome sends authorization TOKEN to ui before it is sent to APIs. So the UI loads but the user is not authorized in APIs so the requests will throw an error.

### Changes
Adds a workaround. UI waits on auth token from chrome (the same that is sent to API) and shows placeholder until auth token is received. This should be solved in chrome , but because they don't own the auth service they cannot do this right now. Maybe they will come up with something in a future.