### PR TITLE
Added api error key form portfolio validation.

### DIFF
--- a/src/Utilities/store.js
+++ b/src/Utilities/store.js
@@ -11,8 +11,8 @@ import platformReducer, { platformInitialState } from '../redux/reducers/platfor
 import portfolioReducer, { portfoliosInitialState } from '../redux/reducers/portfolioReducer';
 
 const registry = new ReducerRegistry({}, [ thunk, promiseMiddleware(), notificationsMiddleware({
-  errorTitleKey: [ 'message' ],
-  errorDescriptionKey: [ 'errors', 'stack' ]
+  errorTitleKey: [ 'errors', 'message' ],
+  errorDescriptionKey: [ 'response.body.errors', 'errors', 'stack' ]
 }), reduxLogger ]);
 
 registry.register({

--- a/src/redux/Actions/PortfolioActions.js
+++ b/src/redux/Actions/PortfolioActions.js
@@ -44,11 +44,6 @@ export const addPortfolio = (portfolioData, items) => ({
         variant: 'success',
         title: 'Success adding portfolio',
         description: 'The portfolio was added successfully.'
-      },
-      rejected: {
-        variant: 'danger',
-        title: 'Failed adding portfolio',
-        description: 'The portfolio was not added successfuly.'
       }
     }
   }


### PR DESCRIPTION
Adds notifications key to show API error responses for portfolio entities. Based on https://github.com/ManageIQ/service_portal-api/pull/107

![screenshot-ci foo redhat com-1337-2019 02 11-10-27-21](https://user-images.githubusercontent.com/22619452/52554624-b3474b00-2de7-11e9-99dc-0ce2e7e51fbc.png)
