### PR TITLE
Added tests for orders redux action creators.

### DIFF
--- a/src/Helpers/Order/OrderHelper.js
+++ b/src/Helpers/Order/OrderHelper.js
@@ -8,11 +8,11 @@ const sspDefaultClient = ServicePortalApi.ApiClient.instance;
 sspDefaultClient.basePath = SERVICE_PORTAL_API_BASE;
 
 export function getServicePlans(portfolioItemId) {
-  return api.fetchPlansWithPortfolioItemId(portfolioItemId).then(data => data, error => console.error(error));
+  return api.fetchPlansWithPortfolioItemId(portfolioItemId);
 }
 
 export function listOrders() {
-  return api.listOrders().then(data => data, error => console.error(error));
+  return api.listOrders();
 }
 
 export async function sendSubmitOrder(parameters) {
@@ -24,5 +24,5 @@ export async function sendSubmitOrder(parameters) {
   orderItem.service_plan_ref = parameters.service_plan_ref;
   orderItem.service_parameters = parameters.service_parameters;
   await api.addToOrder(order.id, orderItem);
-  return api.submitOrder(order.id).then(result => result, error => console.error(error));
+  return api.submitOrder(order.id);
 }

--- a/src/redux/Actions/OrderActions.js
+++ b/src/redux/Actions/OrderActions.js
@@ -23,7 +23,5 @@ export const setSelectedPlan = (data) => ({
 
 export const sendSubmitOrder = apiProps => ({
   type: ActionTypes.SUBMIT_SERVICE_ORDER,
-  payload: new Promise(resolve => {
-    resolve(OrderHelper.sendSubmitOrder(apiProps));
-  })
+  payload: OrderHelper.sendSubmitOrder(apiProps)
 });

--- a/src/test/redux/actions/order-actions.test.js
+++ b/src/test/redux/actions/order-actions.test.js
@@ -1,0 +1,237 @@
+import configureStore from 'redux-mock-store' ;
+import thunk from 'redux-thunk';
+import promiseMiddleware from 'redux-promise-middleware';
+import { notificationsMiddleware, ADD_NOTIFICATION } from '@red-hat-insights/insights-frontend-components/components/Notifications';
+import { SERVICE_PORTAL_API_BASE } from '../../../Utilities/Constants';
+import {
+  fetchServicePlans,
+  fetchOrderList,
+  updateServiceData,
+  setSelectedPlan,
+  sendSubmitOrder
+} from '../../../redux/Actions/OrderActions';
+import {
+  FETCH_SERVICE_PLANS,
+  LIST_ORDERS,
+  UPDATE_SERVICE_DATA,
+  SET_SELECTED_PLAN,
+  SUBMIT_SERVICE_ORDER
+} from '../../../redux/ActionTypes';
+
+describe('Order actions', () => {
+  const middlewares = [ thunk, promiseMiddleware(), notificationsMiddleware() ];
+  let mockStore;
+
+  beforeEach(() => {
+    mockStore = configureStore(middlewares);
+  });
+
+  it('should dispatch correct actions after fetching service plans', () => {
+    const store = mockStore({});
+    apiClientMock.get(`${SERVICE_PORTAL_API_BASE}/portfolio_items/1/service_plans`, mockOnce({
+      body: [ 'Foo' ]
+    }));
+    const expectedActions = [{
+      type: `${FETCH_SERVICE_PLANS}_PENDING`
+    }, expect.objectContaining({
+      type: `${FETCH_SERVICE_PLANS}_FULFILLED`
+    }) ];
+
+    return store.dispatch(fetchServicePlans(1)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should dispatch correct actions after fetching service plans fails', () => {
+    const store = mockStore({});
+    apiClientMock.get(`${SERVICE_PORTAL_API_BASE}/portfolio_items/1/service_plans`, mockOnce({
+      status: 500
+    }));
+    const expectedActions = [{
+      type: `${FETCH_SERVICE_PLANS}_PENDING`
+    }, expect.objectContaining({
+      type: ADD_NOTIFICATION,
+      payload: expect.objectContaining({
+        variant: 'danger'
+      })
+    }), expect.objectContaining({
+      type: `${FETCH_SERVICE_PLANS}_REJECTED`
+    }) ];
+
+    return store.dispatch(fetchServicePlans(1)).catch(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should dispatch correct actions after fetching orders', () => {
+    const store = mockStore({});
+    apiClientMock.get(`${SERVICE_PORTAL_API_BASE}/orders`, mockOnce({
+      body: [ 'Foo' ]
+    }));
+    const expectedActions = [{
+      type: `${LIST_ORDERS}_PENDING`
+    }, expect.objectContaining({
+      type: `${LIST_ORDERS}_FULFILLED`
+    }) ];
+
+    return store.dispatch(fetchOrderList()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should dispatch correct actions after fetching orders fails', () => {
+    const store = mockStore({});
+    apiClientMock.get(`${SERVICE_PORTAL_API_BASE}/orders`, mockOnce({
+      status: 500
+    }));
+    const expectedActions = [{
+      type: `${LIST_ORDERS}_PENDING`
+    }, expect.objectContaining({
+      type: ADD_NOTIFICATION,
+      payload: expect.objectContaining({
+        variant: 'danger'
+      })
+    }), expect.objectContaining({
+      type: `${LIST_ORDERS}_REJECTED`
+    }) ];
+
+    return store.dispatch(fetchOrderList()).catch(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should dispatch correct actions after calling update service data', () => {
+    const store = mockStore({});
+    const expectedActions = [{
+      type: UPDATE_SERVICE_DATA,
+      payload: { serviceData: { foo: 'bar' }}
+    }];
+
+    store.dispatch(updateServiceData({ foo: 'bar' }));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('should dispatch correct actions after calling set selected plan', () => {
+    const store = mockStore({});
+    const expectedActions = [{
+      type: SET_SELECTED_PLAN,
+      payload: { foo: 'bar' }
+    }];
+
+    store.dispatch(setSelectedPlan({ foo: 'bar' }));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('should dispatch correct actions after submitting order', () => {
+    const store = mockStore({});
+    apiClientMock.post(`${SERVICE_PORTAL_API_BASE}/orders`, mockOnce({
+      body: { id: 123 }
+    }));
+    apiClientMock.post(`${SERVICE_PORTAL_API_BASE}/orders/123/items`, mockOnce((req, res) => {
+      expect(JSON.parse(req.body())).toEqual({
+        count: 1,
+        provider_control_parameters: { namespace: 'default' },
+        portfolio_item_id: 'Foo',
+        service_plan_ref: 'Bar',
+        service_parameters: 'Quxx'
+      });
+      return res.status(200);
+    }));
+    apiClientMock.post(`${SERVICE_PORTAL_API_BASE}/orders/123`, mockOnce({
+      status: 200
+    }));
+    const expectedActions = [{
+      type: `${SUBMIT_SERVICE_ORDER}_PENDING`
+    }, expect.objectContaining({
+      type: `${SUBMIT_SERVICE_ORDER}_FULFILLED`
+    }) ];
+
+    return store.dispatch(sendSubmitOrder({
+      portfolio_item_id: 'Foo',
+      service_plan_ref: 'Bar',
+      service_parameters: 'Quxx'
+    })).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should dispatch correct actions after submitting order fails to get new order', () => {
+    const store = mockStore({});
+    apiClientMock.post(`${SERVICE_PORTAL_API_BASE}/orders`, mockOnce({
+      status: 500
+    }));
+    const expectedActions = [{
+      type: `${SUBMIT_SERVICE_ORDER}_PENDING`
+    }, expect.objectContaining({
+      type: ADD_NOTIFICATION,
+      payload: expect.objectContaining({
+        variant: 'danger'
+      })
+    }), expect.objectContaining({
+      type: `${SUBMIT_SERVICE_ORDER}_REJECTED`
+    }) ];
+
+    return store.dispatch(sendSubmitOrder({
+      portfolio_item_id: 'Foo',
+      service_plan_ref: 'Bar',
+      service_parameters: 'Quxx'
+    })).catch(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should dispatch correct actions after submitting order fails to add to new order', () => {
+    const store = mockStore({});
+    apiClientMock.post(`${SERVICE_PORTAL_API_BASE}/orders`, mockOnce({
+      body: { id: 123 }
+    }));
+
+    apiClientMock.post(`${SERVICE_PORTAL_API_BASE}/orders/123/items`, mockOnce({
+      status: 500
+    }));
+
+    const expectedActions = [{
+      type: `${SUBMIT_SERVICE_ORDER}_PENDING`
+    }, expect.objectContaining({
+      type: ADD_NOTIFICATION,
+      payload: expect.objectContaining({
+        variant: 'danger'
+      })
+    }), expect.objectContaining({
+      type: `${SUBMIT_SERVICE_ORDER}_REJECTED`
+    }) ];
+
+    return store.dispatch(sendSubmitOrder({})).catch(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('should dispatch correct actions after submitting order fails to submit order', () => {
+    const store = mockStore({});
+    apiClientMock.post(`${SERVICE_PORTAL_API_BASE}/orders`, mockOnce({
+      body: { id: 123 }
+    }));
+
+    apiClientMock.post(`${SERVICE_PORTAL_API_BASE}/orders/123/items`, mockOnce({
+      status: 200
+    }));
+    apiClientMock.post(`${SERVICE_PORTAL_API_BASE}/orders/123`, mockOnce({
+      status: 500
+    }));
+
+    const expectedActions = [{
+      type: `${SUBMIT_SERVICE_ORDER}_PENDING`
+    }, expect.objectContaining({
+      type: ADD_NOTIFICATION,
+      payload: expect.objectContaining({
+        variant: 'danger'
+      })
+    }), expect.objectContaining({
+      type: `${SUBMIT_SERVICE_ORDER}_REJECTED`
+    }) ];
+
+    return store.dispatch(sendSubmitOrder({})).catch(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});


### PR DESCRIPTION
Some notes:

Seems to that creating order is not an atomic operation on API side. Do we have some scenario what happens when some stage of this process fails?