### PR TITLE
[WIP] Initial pagination for platforms.

### DIFF
--- a/src/Helpers/Platform/PlatformHelper.js
+++ b/src/Helpers/Platform/PlatformHelper.js
@@ -13,9 +13,9 @@ export function getPlatform(platformId) {
 
 export function getPlatformItems(apiProps, page) {
   let apiPromise = null;
-  console.log('apiProps: ', apiProps, page)
   if (apiProps) {
-    apiPromise = fetch(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/${apiProps}/service_offerings?archived_at=&limit=50&offset=${page || 0}`)
+    const url = page || `${TOPOLOGICAL_INVENTORY_API_BASE}/sources/${apiProps}/service_offerings?archived_at=&limit=50&offset=${page || 0}`
+    apiPromise = fetch(url)
     .then(data => data.json());
   } else {
     apiPromise = api.listServiceOfferings();

--- a/src/Helpers/Platform/PlatformHelper.js
+++ b/src/Helpers/Platform/PlatformHelper.js
@@ -11,11 +11,12 @@ export function getPlatform(platformId) {
   return api.showSource(platformId);
 }
 
-export function getPlatformItems(apiProps) {
+export function getPlatformItems(apiProps, page) {
   let apiPromise = null;
-
+  console.log('apiProps: ', apiProps, page)
   if (apiProps) {
-    apiPromise = fetch(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/${apiProps}/service_offerings?archived_at=`).then(data => data.json());
+    apiPromise = fetch(`${TOPOLOGICAL_INVENTORY_API_BASE}/sources/${apiProps}/service_offerings?archived_at=&limit=50&offset=${page || 0}`)
+    .then(data => data.json());
   } else {
     apiPromise = api.listServiceOfferings();
   }

--- a/src/SmartComponents/Platform/Platform.js
+++ b/src/SmartComponents/Platform/Platform.js
@@ -12,8 +12,7 @@ import './platform.scss';
 
 class Platform extends Component {
   state = {
-    filterValue: '',
-    currentOffset: 0
+    filterValue: ''
   };
 
   fetchData(apiProps) {
@@ -35,7 +34,7 @@ class Platform extends Component {
 
   handleFilterChange = filterValue => this.setState({ filterValue });
 
-  handlePageChange = page => this.props.fetchPlatformItems(this.props.match.params.id, page).then(this.setState({ currentOffset: parseInt(page, 10) }))
+  handlePageChange = page => this.props.fetchPlatformItems(this.props.match.params.id, page)
 
   render() {
     let filteredItems = {
@@ -44,7 +43,7 @@ class Platform extends Component {
       .map(data => <PlatformItem key={ data.id } { ...data } />),
       isLoading: this.props.isPlatformDataLoading
     };
-    const { currentOffset } = this.state;
+
     let title = this.props.platform ? this.props.platform.name : '';
 
     return (
@@ -54,9 +53,14 @@ class Platform extends Component {
           { title &&  (<Title size={ '2xl' } > { title }</Title>) }
         </div>
         <div>
-          <button disabled={ currentOffset.toString() === this.props.paginationOffsets.first } onClick={ () => this.handlePageChange(this.props.paginationOffsets.prev) }>Prev</button>
           <button
-            disabled={ currentOffset.toString() === this.props.paginationOffsets.last }
+            disabled={ !this.props.paginationOffsets.prev }
+            onClick={ () => this.handlePageChange(this.props.paginationOffsets.prev) }
+          >
+            Prev
+          </button>
+          <button
+            disabled={ !this.props.paginationOffsets.next }
             onClick={ () => this.handlePageChange(this.props.paginationOffsets.next) }
           >
             Next

--- a/src/redux/Actions/PlatformActions.js
+++ b/src/redux/Actions/PlatformActions.js
@@ -13,9 +13,9 @@ export const fetchPlatforms = () => (dispatch, getState) => {
   }
 };
 
-export const fetchPlatformItems = platformId => ({
+export const fetchPlatformItems = (platformId, page) => ({
   type: ActionTypes.FETCH_PLATFORM_ITEMS,
-  payload: PlatformHelper.getPlatformItems(platformId).then(({ data }) => data),
+  payload: PlatformHelper.getPlatformItems(platformId, page),
   meta: {
     platformId
   }

--- a/src/redux/reducers/platformReducer.js
+++ b/src/redux/reducers/platformReducer.js
@@ -17,20 +17,13 @@ export const platformInitialState = {
   filterValue: ''
 };
 
-const generateLinksData = links => Object.keys(links).reduce((acc, key) => ({
-  ...acc,
-  [key]: links[key] && links[key].substring(links[key].lastIndexOf('offset') + 'offset'.length + 1)
-}), {});
-
 // rename isPlatformLoading.. to isLoaing so we can use common action for loading states
 
 const setLoadingState = state => ({ ...state, isPlatformDataLoading: true });
 const setPlatforms = (state, { payload }) => ({ ...state, platforms: payload, isPlatformDataLoading: false });
 const setPlatformItems = (state, { payload, meta: { platformId }}) =>
-  ({ ...state, platformItems: { ...state.platformItems, [platformId]: {
-    ...payload,
-    links: generateLinksData(payload.links) }},
-  isPlatformDataLoading: false
+  ({ ...state, platformItems: { ...state.platformItems, [platformId]: payload },
+    isPlatformDataLoading: false
   });
 const setMultiplePlatformItems = (state, { payload }) =>
   ({ ...state, platformItems: { ...state.platformItems, ...payload }, isPlatformDataLoading: false });

--- a/src/redux/reducers/platformReducer.js
+++ b/src/redux/reducers/platformReducer.js
@@ -17,12 +17,21 @@ export const platformInitialState = {
   filterValue: ''
 };
 
+const generateLinksData = links => Object.keys(links).reduce((acc, key) => ({
+  ...acc,
+  [key]: links[key] && links[key].substring(links[key].lastIndexOf('offset') + 'offset'.length + 1)
+}), {});
+
 // rename isPlatformLoading.. to isLoaing so we can use common action for loading states
 
 const setLoadingState = state => ({ ...state, isPlatformDataLoading: true });
 const setPlatforms = (state, { payload }) => ({ ...state, platforms: payload, isPlatformDataLoading: false });
 const setPlatformItems = (state, { payload, meta: { platformId }}) =>
-  ({ ...state, platformItems: { ...state.platformItems, [platformId]: payload }, isPlatformDataLoading: false });
+  ({ ...state, platformItems: { ...state.platformItems, [platformId]: {
+    ...payload,
+    links: generateLinksData(payload.links) }},
+  isPlatformDataLoading: false
+  });
 const setMultiplePlatformItems = (state, { payload }) =>
   ({ ...state, platformItems: { ...state.platformItems, ...payload }, isPlatformDataLoading: false });
 const setPortfolioItems = (state, { payload }) => ({ ...state, portfolioItem: payload, isPlatformDataLoading: false });


### PR DESCRIPTION
Adds initial and very simple pagination for platform items.

### TODO
- fix prev/next requests
  - requires fix in topology API to send correct endpoints
  - offset is not computed from strings
- enable archived at as a attribute for `listSourceServiceOfferings`
  - more info: https://github.com/ManageIQ/topological_inventory-api-jsclient/blob/master/docs/DefaultApi.md#example-37
- screen designs
- filtering? Cannot combine server side pagination with client side filtering. Can be done on if all entities are given