### PR TITLE
Custom select

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -81,7 +81,11 @@ rules:
     - warn
     - functions: false
   no-undef: 2
-  no-unused-vars: 2
+  no-unused-vars:
+    - error
+    - vars: all
+      args: after-used
+      ignoreRestSiblings: true
   no-var: 2
   no-with: 2
   object-shorthand: 2

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-core": "^1.51.6",
     "@patternfly/react-icons": "^2.10.0",
     "@patternfly/react-tokens": "^1.10.0",
-    "@red-hat-insights/insights-frontend-components": "^3.33.4",
+    "@red-hat-insights/insights-frontend-components": "^3.33.65",
     "font-awesome": "^4.7.0",
     "lodash": "^4.17.10",
     "patternfly-react": "^2.13.1",

--- a/src/PresentationalComponents/Shared/pf4-select-wrapper.js
+++ b/src/PresentationalComponents/Shared/pf4-select-wrapper.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormSelect, FormSelectOption, FormGroup, TextContent, Text, TextVariants } from '@patternfly/react-core';
+
+const createOptions = (options, inputValue, isRequired) => {
+  if (inputValue && isRequired) {
+    return options;
+  }
+
+  let selectOptions = [ ...options ];
+  return selectOptions.find(({ value }) => value === undefined)
+    ? [ ...selectOptions ]
+    : [{ label: isRequired ? 'Please choose' : 'None' }, ...selectOptions ];
+};
+
+const Select = ({
+  input,
+  options,
+  isReadOnly,
+  isDisabled,
+  FieldProvider,
+  isRequired,
+  ...rest
+}) => (
+  <FormSelect { ...input } { ...rest } isDisabled={ isDisabled || isReadOnly }>
+    { createOptions(options, input.value, isRequired).map((props) => (
+      <FormSelectOption key={ props.value || props.label } { ...props } label={ props.label.toString() }/> // eslint-disable-line react/prop-types
+    )) }
+  </FormSelect>
+);
+
+Select.propTypes = {
+  input: PropTypes.object.isRequired,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.any.isRequired,
+    label: PropTypes.string
+  })).isRequired,
+  isReadOnly: PropTypes.bool,
+  isDisabled: PropTypes.bool,
+  isRequired: PropTypes.bool,
+  FieldProvider: PropTypes
+};
+
+const Pf4SelectWrapper = ({
+  componentType,
+  label,
+  isRequired,
+  helperText,
+  meta,
+  description,
+  hideLabel,
+  ...rest
+}) => {
+  const { error, touched } = meta;
+  const showError = touched && error;
+
+  return (
+    <FormGroup
+      isRequired={ isRequired }
+      label={ !hideLabel && label }
+      fieldId={ rest.id }
+      isValid={ !showError }
+      helperText={ helperText }
+      helperTextInvalid={ meta.error }
+    >
+      { description && <TextContent><Text component={ TextVariants.small }>{ description }</Text></TextContent> }
+      <Select label={ label } isValid={ !showError } isRequired={ isRequired } { ...rest }/>
+    </FormGroup>
+  );
+};
+
+Pf4SelectWrapper.propTypes = {
+  componentType: PropTypes.string,
+  label: PropTypes.string,
+  isRequired: PropTypes.bool,
+  helperText: PropTypes.string,
+  meta: PropTypes.object,
+  description: PropTypes.string,
+  hideLabel: PropTypes.bool
+};
+
+export default Pf4SelectWrapper;

--- a/src/SmartComponents/Common/FormRenderer.js
+++ b/src/SmartComponents/Common/FormRenderer.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import ReactFormRender from '@data-driven-forms/react-form-renderer';
 import PropTypes from 'prop-types';
+import ReactFormRender, { componentTypes } from '@data-driven-forms/react-form-renderer';
 import { layoutMapper, formFieldsMapper } from '@data-driven-forms/pf4-component-mapper';
+import Pf4SelectWrapper from '../../PresentationalComponents/Shared/pf4-select-wrapper';
 
 const buttonPositioning = {
   default: {},
@@ -16,7 +17,8 @@ const FormRenderer = ({ componentMapper, formContainer, ...rest }) => (
     <ReactFormRender
       formFieldsMapper={ {
         ...formFieldsMapper,
-        componentMapper
+        componentMapper,
+        [componentTypes.SELECT]: Pf4SelectWrapper
       } }
       layoutMapper={ layoutMapper }
       { ...buttonPositioning[formContainer] }


### PR DESCRIPTION
Fixes issue with PF4 select not handling empty input value.

### Changes
- upgrade insights fronted components. Fixes transparent background
- Adds empty option to select if no value is selected
  - empty option with value `undefined` will not let user submit the form until he chooses something
  - why not add initial value? We cannot hard code initial value because we don't know what fields and values will be send from API. Also API response does not include default value.

![select](https://user-images.githubusercontent.com/22619452/52782002-3e297f00-304e-11e9-843e-3a6cda4a2b8d.gif)