### PR TITLE
Service offering card update

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -61,3 +61,11 @@ ul.navigation-secondary {
     }
   }
 }
+
+.line-clamp {
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;  
+  overflow: hidden;
+  word-wrap: break-word;
+}

--- a/src/PresentationalComponents/Platform/PlatformItem.js
+++ b/src/PresentationalComponents/Platform/PlatformItem.js
@@ -1,53 +1,38 @@
 import React from 'react';
 import './platformcard.scss';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import CatItemSvg from '../../assets/images/vendor-openshift.svg';
 import ImageWithDefault from '../Shared/ImageWithDefault';
-import { GridItem, Card, CardHeader, CardBody, CardFooter, Text, TextContent, TextVariants } from '@patternfly/react-core';
-import ItemDetails from '../../PresentationalComponents/Shared/CardCommon';
+import { GridItem, Card, CardHeader, CardFooter } from '@patternfly/react-core';
 import CardCheckbox from '../Shared/CardCheckbox';
+import ServiceOfferingCardBody from '../Shared/service-offering-body';
 
-const TO_DISPLAY = [ 'description' ];
-
-class PlatformItem extends React.Component {
-    state = {
-      isOpen: true
-    };
-
-    render() {
-      return (
-        <GridItem key={ this.props.id } sm={ 6 } md={ 4 } lg={ 4 } xl={ 3 }>
-          <Card key={ this.props.id }>
-            <CardHeader className="pcard_header">
-              <ImageWithDefault src={ this.props.imageUrl || CatItemSvg } width="30" height="20" />
-              { this.props.editMode && (
-                <CardCheckbox
-                  id={ this.props.id }
-                  checked={ this.props.checked }
-                  onChange={ this.props.onToggleItemSelect }
-                />
-              ) }
-            </CardHeader>
-            <CardBody>
-              <TextContent>
-                <Text component={ TextVariants.h3 }>{ this.props.name }</Text>
-              </TextContent>
-              <ItemDetails { ...this.props } toDisplay={ TO_DISPLAY } />
-            </CardBody>
-            <CardFooter/>
-          </Card>
-        </GridItem>
-      );
-    };
-}
+const PlatformItem = props =>(
+  <GridItem key={ props.id } sm={ 12 } md={ 6 } lg={ 4 } xl={ 3 }>
+    <Card key={ props.id }>
+      <CardHeader className="pcard_header">
+        <ImageWithDefault src={ props.imageUrl || CatItemSvg } width="30" height="20" />
+        { props.editMode && (
+          <CardCheckbox
+            id={ props.id }
+            checked={ props.checked }
+            onChange={ props.onToggleItemSelect }
+          />
+        ) }
+      </CardHeader>
+      <ServiceOfferingCardBody { ...props }/>
+      <CardFooter/>
+    </Card>
+  </GridItem>
+);
 
 PlatformItem.propTypes = {
-  imageUrl: propTypes.string,
-  id: propTypes.string,
-  name: propTypes.string,
-  editMode: propTypes.bool,
-  checked: propTypes.bool,
-  onToggleItemSelect: propTypes.func
+  imageUrl: PropTypes.string,
+  id: PropTypes.string,
+  name: PropTypes.string,
+  editMode: PropTypes.bool,
+  checked: PropTypes.bool,
+  onToggleItemSelect: PropTypes.func
 };
 
 export default PlatformItem;

--- a/src/PresentationalComponents/Platform/platformcard.scss
+++ b/src/PresentationalComponents/Platform/platformcard.scss
@@ -9,8 +9,3 @@
   overflow: hidden;
   font-size: small;
 }
-
-.pcard_element {
-  text-align: left;
-  font-size: small;
-}

--- a/src/PresentationalComponents/Shared/CardCommon.js
+++ b/src/PresentationalComponents/Shared/CardCommon.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-// This whole thing is a bit strange
-const PropLine = ({ value }) => <div className = "card_element">{ value }</div>;
+const PropLine = ({ value }) => <div>{ value }</div>;
 
 PropLine.propTypes = {
   value: PropTypes.oneOfType([
@@ -16,7 +15,7 @@ PropLine.propTypes = {
 };
 
 const ItemDetails = ({ toDisplay = [], ...item }) => (
-  <div>
+  <div className="line-clamp">
     { toDisplay.map(prop => <PropLine key={ `card-prop-${prop}` } value={ item[prop] } />) }
   </div>
 );

--- a/src/PresentationalComponents/Shared/service-offering-body.js
+++ b/src/PresentationalComponents/Shared/service-offering-body.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CardBody, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import ItemDetails from './CardCommon';
+
+const ServiceOfferingCardBody = ({ name, display_name, distributor, ...props }) =>(
+  <CardBody style={ { height: 240 } }>
+    <TextContent>
+      <Text
+        className="elipsis-text-overflow"
+        component={ TextVariants.h3 }
+        title={ display_name || name }
+      >
+        { display_name || name }
+      </Text>
+      <Text component={ TextVariants.small }>{ distributor }&nbsp;</Text>
+    </TextContent>
+    <ItemDetails { ...props } toDisplay={ [ props.long_description ? 'long_description' : 'description' ] } />
+  </CardBody>
+);
+
+ServiceOfferingCardBody.propTypes = {
+  name: PropTypes.string,
+  display_name: PropTypes.string,
+  distributor: PropTypes.string,
+  long_description: PropTypes.string
+};
+
+export default ServiceOfferingCardBody;

--- a/src/SmartComponents/Portfolio/PortfolioItem.js
+++ b/src/SmartComponents/Portfolio/PortfolioItem.js
@@ -5,12 +5,10 @@ import './portfolioitem.scss';
 import propTypes from 'prop-types';
 import CatItemSvg from '../../assets/images/vendor-openshift.svg';
 import ImageWithDefault from '../../PresentationalComponents/Shared/ImageWithDefault';
-import ItemDetails from '../../PresentationalComponents/Shared/CardCommon';
 import { hideModal, showModal } from '../../redux/Actions/MainModalActions';
-import { GridItem, Card, CardHeader, CardBody, CardFooter } from '@patternfly/react-core';
+import { GridItem, Card, CardHeader, CardFooter } from '@patternfly/react-core';
 import CardCheckbox from '../../SmartComponents/Common/CardCheckbox';
-
-const TO_DISPLAY = [ 'description' ];
+import ServiceOfferingCardBody from '../../PresentationalComponents/Shared/service-offering-body';
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   hideModal,
@@ -43,10 +41,7 @@ class PortfolioItem extends Component {
               }
               <ImageWithDefault src={ this.props.imageUrl || CatItemSvg } width="30" height="20" />
             </CardHeader>
-            <CardBody className="card_body">
-              <h4>{ this.props.name }</h4>
-              <ItemDetails { ...this.props } toDisplay={ TO_DISPLAY } />
-            </CardBody>
+            <ServiceOfferingCardBody { ...this.props }/>
             <CardFooter>
             </CardFooter>
           </div>

--- a/src/SmartComponents/Portfolio/portfolioitem.scss
+++ b/src/SmartComponents/Portfolio/portfolioitem.scss
@@ -4,13 +4,3 @@
   height: 60px;
 }
 
-.card_body {
-  height: 140px;
-  overflow: hidden;
-}
-
-.card_element {
-  text-align: left;
-  font-size: small;
-}
-


### PR DESCRIPTION
I've noticed that topological API now returns more data that is closer match to our mocks.

### Changes
- updated displayed information
- remove duplicate code (platform/portfolio cards) and created common card component
- update layout styling for service offering cards

### Issues
- ServiceOffering response payload
  - ~~The service offering response from TopologicalAPI gives me more data (display name, distributor etc.) than the portfolio items SSP API response. This means that portfolio items does not have complete information about the service offering~~.

![screenshot-ci foo redhat com-1337-2019 02 14-14-21-39](https://user-images.githubusercontent.com/22619452/52791515-68d50100-3069-11e9-8955-245621aa4b16.png)
